### PR TITLE
Add MQTT authentication option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ ha_display/temperature (published by the device)
 ```
 
 Configure WiFi and MQTT parameters in `include/config.h` or create `config_private.h` with overriding values.
+If your MQTT broker requires authentication, define `CONFIG_MQTT_USER` and `CONFIG_MQTT_PASS` in `config_private.h`.

--- a/include/config.h
+++ b/include/config.h
@@ -23,6 +23,14 @@
 #define CONFIG_MQTT_PORT 1883
 #endif
 
+#ifndef CONFIG_MQTT_USER
+#define CONFIG_MQTT_USER ""
+#endif
+
+#ifndef CONFIG_MQTT_PASS
+#define CONFIG_MQTT_PASS ""
+#endif
+
 // Pin assignments for the Wemos LOLIN S2 mini board
 // SCL   GPIO7  - grey
 // SDA   GPIO11 - purple

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,7 +143,13 @@ static void mqttConnect() {
   while (!mqtt.connected()) {
     String clientId = "esp32-display-" + String(random(0xffff), HEX);
     Serial.print("Connecting to MQTT...");
-    if (mqtt.connect(clientId.c_str())) {
+    bool connected = false;
+    if (strlen(CONFIG_MQTT_USER) > 0) {
+      connected = mqtt.connect(clientId.c_str(), CONFIG_MQTT_USER, CONFIG_MQTT_PASS);
+    } else {
+      connected = mqtt.connect(clientId.c_str());
+    }
+    if (connected) {
       Serial.println("connected");
       mqtt.subscribe("ha_display/arc1");
       mqtt.subscribe("ha_display/arc2");


### PR DESCRIPTION
## Summary
- allow MQTT username and password configuration
- connect using credentials if provided
- document how to set MQTT user/pass

## Testing
- `pio run` *(fails: `pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d5e742338832bba9b29f49b0b1d94