### PR TITLE
Add JSON trace output in MQTT callback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,6 +191,9 @@ static void mqttCallback(char* topic, byte* payload, unsigned int length) {
   StaticJsonDocument<256> doc;
   DeserializationError err = deserializeJson(doc, payload, length);
   if (!err) {
+    Serial.print("Parsed JSON: ");
+    serializeJson(doc, Serial);
+    Serial.println();
     if (strcmp(topic, "ha_display/arc1") == 0) {
       handleArc(0, doc);
     } else if (strcmp(topic, "ha_display/arc2") == 0) {


### PR DESCRIPTION
## Summary
- add new debug printing for parsed MQTT messages

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d75985434832bb0995890755d188c