### PR TITLE
Add animation config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Supported fields:
 * `min`/`max` – optional range used to calculate the percentage
 * `width` – arc thickness (for `arc1`..`arc3` only)
 * `color` – hex color (e.g. `"#00ff00"`)
+* `animation` – `true`/`false` to enable or disable animation or a number
+  specifying the animation duration in milliseconds (default `1000`)
 
 Configure WiFi and MQTT parameters in `include/config.h` or create `config_private.h` with overriding values.
 If your MQTT broker requires authentication, define `CONFIG_MQTT_USER` and `CONFIG_MQTT_PASS` in `config_private.h`.


### PR DESCRIPTION
## Summary
- set animation duration to 1s by default
- allow animation on/off/duration from JSON
- update README with new field

## Testing
- `pip install platformio`
- `platformio run` *(fails: Build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684d80ab496c832ba6c0e176aba28b6c